### PR TITLE
The preload function was refactored to a load function

### DIFF
--- a/src/routes/[...lang]/docs/configuration.svelte
+++ b/src/routes/[...lang]/docs/configuration.svelte
@@ -61,7 +61,7 @@ addMessages('es', es);
 </p>
 
 <p>
-	{$t('configuration.paragraph.dynamic-locales-4')} <CodeInline>preload</CodeInline> 
+	{$t('configuration.paragraph.dynamic-locales-4')} <CodeInline>load</CodeInline> 
   {$t('configuration.paragraph.dynamic-locales-5')}
 </p>
 
@@ -71,8 +71,9 @@ register('en', () => import('$locales/en'));
 register('es', () => import('$locales/es'));
 init({ initialLocale: en });
 
-export async function preload() {
-  return waitLocale(); // awaits the default locale, "en" in this case.
+export async function load() {
+  await waitLocale(); // awaits the default locale, "en" in this case.
+  return {};
 }
 `}</Codeblock>
 
@@ -95,8 +96,9 @@ export async function preload() {
   registerAll();
   init({ initialLocale: selectBestMatchingLocale(availableLocales) });
   
-  export async function preload() {
-    return waitLocale();
+  export async function load() {
+    await waitLocale();
+	return {};
   }
   `}</Codeblock>
 

--- a/src/routes/[...lang]/docs/configuration.svelte
+++ b/src/routes/[...lang]/docs/configuration.svelte
@@ -98,7 +98,7 @@ export async function load() {
   
   export async function load() {
     await waitLocale();
-	return {};
+    return {};
   }
   `}</Codeblock>
 

--- a/src/routes/[...lang]/docs/configuration.svelte
+++ b/src/routes/[...lang]/docs/configuration.svelte
@@ -69,9 +69,9 @@ addMessages('es', es);
 import { init, register, waitLocale } from 'svelte-intl-precompile';
 register('en', () => import('$locales/en'));
 register('es', () => import('$locales/es'));
-init({ initialLocale: en });
 
 export async function load() {
+  init({ initialLocale: en });
   await waitLocale(); // awaits the default locale, "en" in this case.
   return {};
 }
@@ -94,9 +94,9 @@ export async function load() {
   import { registerAll, availableLocales } from '$locales';
   
   registerAll();
-  init({ initialLocale: selectBestMatchingLocale(availableLocales) });
   
   export async function load() {
+    init({ initialLocale: selectBestMatchingLocale(availableLocales) });
     await waitLocale();
     return {};
   }


### PR DESCRIPTION
The preload() function does not exist anymore. Now there is a load() function with a slightly different API.

https://kit.svelte.dev/docs/migrating#pages-and-layouts-preload