### PR TITLE
Extend documentation with getLocaleFromAcceptLanguageHeader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /build
 /.svelte-kit
 /package
+/.idea

--- a/locales/en.json
+++ b/locales/en.json
@@ -140,6 +140,7 @@
   "configuration.definitions.hash": "Like <pre class='inline'>getLocaleFromQueryString</pre> but for the URL hash.<br>E.g <pre class='inline'>getLocaleFromHash('lang')</pre> for <pre class='inline'>/users#sort=name&amp;dir=asc&amp;lang=es</pre>",
   "configuration.definitions.path": "Extracts the locale from the path of the URL.<br>E.g <pre class='inline'>getLocaleFromPathname(/^\/((es|en)(-\\w\\w)?)/)</pre> for <pre class='inline'>myapp.com/en-US/users</pre>",
   "configuration.definitions.host": "Extracts the locale from host.<br>E.g <pre class='inline'>getLocaleFromHostname(/^((es|en)(-\\w\\w)?)\\./)</pre> for <pre class='inline'>https://pt.myapp.com</pre>",
+  "configuration.definitions.acceptLanguage": "Extracts the locale from the Accept-Language header based on a list of available locales. If availableLocales is omitted, returns the first language from the header.<br>E.g. <pre class='inline'>getLocaleFromAcceptLanguageHeader('en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', ['fr', 'es', 'de'])</pre> for <pre class='inline'>'es'</pre>",
   "configuration.subsection.custom-formats": "Custom formats",
   "configuration.paragraph.custom-formats-1": "This library can format numbers, dates and times. It does it without adding significant weight to your app by leveraging the Intl API already present in all modern browsers and in Node.js.<br/>By default you app can use these formats, but you can add your own.",
   "configuration.paragraph.custom-formats-2": "If you want to define your own formats pass them on initialization using the",

--- a/src/routes/[...lang]/docs/configuration.svelte
+++ b/src/routes/[...lang]/docs/configuration.svelte
@@ -148,6 +148,10 @@ addMessages('es', es);
     <svelte:fragment slot="dt"><pre>getLocaleFromHostname(regex)</svelte:fragment>
     <svelte:fragment slot="dd">{@html $t('configuration.definitions.host')}</svelte:fragment>
   </DefinitionEntry>
+  <DefinitionEntry background="gray">
+    <svelte:fragment slot="dt"><pre>getLocaleFromAcceptLanguageHeader(header, availableLocales?)</pre></svelte:fragment>
+    <svelte:fragment slot="dd">{@html $t('configuration.definitions.acceptLanguage')}</svelte:fragment>
+  </DefinitionEntry>
 </dl>
 
 <h2 class="text-xl font-semibold" id="custom-formats">{$t('configuration.subsection.custom-formats')}</h2>


### PR DESCRIPTION
I have extended the documentation with the new `getLocaleFromAcceptLanguageHeader()` function from [precompile-intl-runtime](https://github.com/cibernox/precompile-intl-runtime).

This Pull request should only be merged, after the package [svelte-intl-precompile](https://github.com/cibernox/svelte-intl-precompile) includes this function.